### PR TITLE
Correct auto update re-exec process on linux

### DIFF
--- a/core/auto_updater.py
+++ b/core/auto_updater.py
@@ -126,7 +126,11 @@ def perform_updates(updates: tuple[Update, ...] | None = None) -> None:
                 finally:
                     delete(archive_path)
 
-                os.execve(sys.executable, [sys.executable] + sys.argv, os.environ) # NOTE: calls `exec()` and restarts the program
+                # users that are using system python should not be auto updating anyway
+                # (i.e. assume we're running in a venv and using the runscript)
+                # we also need to remove the first item in argv, since `./main.py` actually executes `python3 ./main.py`
+                run_script = config.install_dir / 'scripts/run.sh'
+                os.execve(run_script, [run_script] + sys.argv[1:], os.environ) # NOTE: calls `exec()` and restarts the program
 
             case _:
                 raise NotImplementedError


### PR DESCRIPTION
We need to re-execute the run script itself, not just the python interpreter to ensure the virtual environment has everything it needs.

To reproduce:
```sh
# (in an empty directory)
git clone --recursive https://github.com/cueki/casual-pre-loader
cd casual-pre-loader
git checkout v2.2.4
 # run the first time install then let it update
 # you should get an error when trying to import `cappa`
./scripts/run.sh -v
```

I've added some temporary releases on my fork for testing:
```sh
# (in an empty directory)
git clone --recursive https://github.com/djsigmann/casual-pre-loader
cd casual-pre-loader
git checkout v2.3.1
# run the first time install then let it update to 2.3.2
# it should succeed and correctly still show debug output after re-executing
./scripts/run.sh -v
```

Fixes #291